### PR TITLE
Fix OSError if the default project is not set

### DIFF
--- a/bq_jobrunner/bq_jobrunner.py
+++ b/bq_jobrunner/bq_jobrunner.py
@@ -23,7 +23,7 @@ class BQJobrunner:
         self.location = location
         if credentials_path:
             os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = credentials_path
-        self.client = bigquery.Client()
+        self.client = bigquery.Client(project_id)
         self.jobs = {}
         self.processed_jobs = []
         self.to_json = {}


### PR DESCRIPTION
The following error occurs if the default project is not set.

> OSError: Project was not passed and could not be determined from the environment.